### PR TITLE
Fix _build_order_by() using real connection instead of default

### DIFF
--- a/src/idiorm/orm/ORM.php
+++ b/src/idiorm/orm/ORM.php
@@ -2498,7 +2498,7 @@ class ORM implements \ArrayAccess
       return '';
     }
 
-    $db = static::get_db(self::DEFAULT_CONNECTION);
+    $db = static::get_db($this->_connection_name);
 
     return 'ORDER BY ' . trim($db->quote(implode(', ', $this->_order_by)), "'");
   }


### PR DESCRIPTION
Current build 2.1.4 won't work with multiple connections because _build_order_by() is using default connection and not the one from $this->_connection_name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/voku/idiorm/5)
<!-- Reviewable:end -->
